### PR TITLE
Add extra check for 2RSS to better work with true diversity receivers

### DIFF
--- a/src/WIDGETS/ELRST/main.lua
+++ b/src/WIDGETS/ELRST/main.lua
@@ -353,7 +353,9 @@ local function refresh(widget, event, touchState)
   local Y = 1
 
   local tlm = { rssi1 = getV("1RSS") }
-  if not widget.DEBUG and (tlm.rssi1 == nil or tlm.rssi1 == 0) then
+  -- True diversity receivers sometimes only report one of the RSSI values, so we need to check both
+  local rssi2 = getV("2RSS")
+  if not widget.DEBUG and ((tlm.rssi1 == nil or tlm.rssi1 == 0) and (rssi2 == nil or rssi2 == 0)) then
     lcd.drawText(widget.zw / 2, Y, "No RX Connected", COLOR_THEME_PRIMARY1 + CENTER)
     Y = Y + TH
     if widget.gps == nil then


### PR DESCRIPTION
True diversity receivers only have one "side" active at a time, so they report either 1RSS or 2RSS, with the other being 0, specially at startup. If, during startup, only 2RSS is active and reported, the widget doesn't recognize the Rx connection and keeps displaying the "No RX connected" message until 1RSS become active, which depending on the Rx environment, can take a while (it will usually only be activated once the RF link strength on the 2RSS "side" falls significantly). But since the 2RSS "side" is working properly, the Rx IS connected and working normally, so the widget can be misleading. This is the behavior I experienced with two distinct Happymodel EP1 Dual TCXO's.

This change aims to fix that, by checking that both 1RSS and 2RSS are zero (or nil) before considering as no RX connected. If either of them (or both) is non-zero (i.e. active), it considers as a normal connection.

I have tested with both EP1 Duals and some other non-diversity Rx's and it seems to work properly, but further testing is more than welcome.